### PR TITLE
Add music + SFX nodes: track and sound effects generated from the rendered cut (Sonilo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ credits, cloud rendering, support, and convenience.
 | Node workflows | Node Space for graph-style creative pipelines and production chains |
 | Film planning | Story bible, worldbuilding, Scene Wall, set design, moodboards, and production references |
 | Editing | Timeline, grading, effects, audio, export, OpenTimelineIO/FCPXML-style handoff utilities |
-| Providers | Gemini, FAL, Replicate, xAI, ElevenLabs, Sonauto, Brave Search, Supabase, Stripe, and related integrations |
+| Providers | Gemini, FAL, Replicate, xAI, ElevenLabs, Sonauto, Sonilo, Brave Search, Supabase, Stripe, and related integrations |
 | Models | GPT Image, Nano Banana, Seedance, Kling, Happy Horse, Veo, WAN, LTX, Grok, Seedream, Qwen, Flux, and related adapters |
 | Extensibility | Provider services, workspace components, SDK package, hosted BYOK/proxy APIs |
 

--- a/docs/CAPABILITY_MAP.md
+++ b/docs/CAPABILITY_MAP.md
@@ -37,7 +37,7 @@ first, then come back here when you want code pointers.
 | Smart model routing | Scores model candidates by quality, speed, cost, and balanced intent. | `src/utils/smartModelRouter.ts` |
 | FAL provider integration | Supports image/video model calls through FAL-style APIs. | `src/services/falAiService.ts` |
 | Gemini provider integration | Powers script analysis, Director work, image/text reasoning, continuity and critique flows. | `src/services/geminiService.ts`, `src/services/googleModelProvider.ts` |
-| Replicate, xAI, ElevenLabs, Sonauto, LTX | Provider-specific adapters for image, video, audio, and related generation tasks. | `src/services/replicateService.ts`, `src/services/xaiService.ts`, `src/services/elevenLabsService.ts`, `src/services/sonautoService.ts`, `src/services/ltxService.ts` |
+| Replicate, xAI, ElevenLabs, Sonauto, Sonilo, LTX | Provider-specific adapters for image, video, audio, and related generation tasks. | `src/services/replicateService.ts`, `src/services/xaiService.ts`, `src/services/elevenLabsService.ts`, `src/services/sonautoService.ts`, `src/services/soniloService.ts`, `src/services/ltxService.ts` |
 | BYOK proxy layer | Optional hosted/key-routing layer for teams or managed deployments. | `src/services/byokProxyClient.ts`, `server/byok`, `api` |
 
 ## Workspace Surface

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -791,6 +791,7 @@ const hasAnyLocalApiKey = () => {
         localStorage.getItem('xai_api_key') ||
         localStorage.getItem('worldlabs_api_key') ||
         localStorage.getItem('sonauto_api_key') ||
+        localStorage.getItem('sonilo_api_key') ||
         localStorage.getItem('unsplash_access_key')
     );
 };
@@ -6236,6 +6237,7 @@ function App() {
         elevenlabs: 'https://elevenlabs.io/app/settings/api-keys',
         worldlabs: 'https://platform.worldlabs.ai/',
         sonauto: 'https://sonauto.ai/developers',
+        sonilo: 'https://platform.sonilo.com/dashboard/api-keys',
         unsplash: 'https://unsplash.com/developers',
     } as const;
 
@@ -6608,7 +6610,7 @@ function App() {
                 properties: {
                     provider: {
                         type: Type.STRING,
-                        enum: ['gemini', 'replicate', 'fal', 'ltx', 'xai', 'elevenlabs', 'worldlabs', 'sonauto', 'unsplash'],
+                        enum: ['gemini', 'replicate', 'fal', 'ltx', 'xai', 'elevenlabs', 'worldlabs', 'sonauto', 'sonilo', 'unsplash'],
                     },
                 },
                 required: ['provider'],
@@ -7140,6 +7142,7 @@ function App() {
                 elevenlabs: Boolean(localStorage.getItem('elevenlabs_api_key')),
                 worldlabs: Boolean(localStorage.getItem('worldlabs_api_key')),
                 sonauto: Boolean(localStorage.getItem('sonauto_api_key')),
+                sonilo: Boolean(localStorage.getItem('sonilo_api_key')),
                 unsplash: Boolean(localStorage.getItem('unsplash_access_key')),
             };
             return {
@@ -7168,6 +7171,7 @@ function App() {
                     elevenlabs: Boolean(localStorage.getItem('elevenlabs_api_key')),
                     worldlabs: Boolean(localStorage.getItem('worldlabs_api_key')),
                     sonauto: Boolean(localStorage.getItem('sonauto_api_key')),
+                    sonilo: Boolean(localStorage.getItem('sonilo_api_key')),
                     unsplash: Boolean(localStorage.getItem('unsplash_access_key')),
                 },
                 moodboard: (storyBible.categorizedMoodboard?.items?.length || storyBible.moodboard?.length || 0) > 0,

--- a/src/components/ApiKeyModal.tsx
+++ b/src/components/ApiKeyModal.tsx
@@ -532,7 +532,7 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({
                                 <LockIcon className="w-4 h-4" />
                             </div>
                         </div>
-                        <p className="text-[10px] app-muted mt-2">Used for the Music node in Node Space: a licensed track generated from a rendered video.</p>
+                        <p className="text-[10px] app-muted mt-2">Used for the Music and SFX nodes in Node Space: a licensed track, or royalty-free sound effects, generated from a rendered video.</p>
                         <p className="text-[10px] app-muted mt-1">
                             Get a key at{' '}
                             <a

--- a/src/components/ApiKeyModal.tsx
+++ b/src/components/ApiKeyModal.tsx
@@ -50,6 +50,7 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({
     const [xaiKey, setXaiKey] = useState('');
     const [elevenLabsKey, setElevenLabsKey] = useState('');
     const [sonautoKey, setSonautoKey] = useState('');
+    const [soniloKey, setSoniloKey] = useState('');
     const [falKey, setFalKey] = useState('');
     const [ltxKey, setLtxKey] = useState('');
     const [worldLabsKey, setWorldLabsKey] = useState('');
@@ -64,6 +65,7 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({
     const [xaiSaved, setXaiSaved] = useState(false);
     const [elevenLabsSaved, setElevenLabsSaved] = useState(false);
     const [sonautoSaved, setSonautoSaved] = useState(false);
+    const [soniloSaved, setSoniloSaved] = useState(false);
     const [falSaved, setFalSaved] = useState(false);
     const [ltxSaved, setLtxSaved] = useState(false);
     const [worldLabsSaved, setWorldLabsSaved] = useState(false);
@@ -80,6 +82,7 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({
         const storedXai = localStorage.getItem('xai_api_key');
         const storedElevenLabs = localStorage.getItem('elevenlabs_api_key');
         const storedSonauto = localStorage.getItem('sonauto_api_key');
+        const storedSonilo = localStorage.getItem('sonilo_api_key');
         const storedFal = localStorage.getItem('fal_api_key');
         const storedLtx = localStorage.getItem('ltx_api_key');
         const storedWorldLabs = localStorage.getItem('worldlabs_api_key');
@@ -108,6 +111,10 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({
         if (storedSonauto) {
             setSonautoKey(storedSonauto);
             setSonautoSaved(true);
+        }
+        if (storedSonilo) {
+            setSoniloKey(storedSonilo);
+            setSoniloSaved(true);
         }
         if (storedFal) {
             setFalKey(storedFal);
@@ -215,7 +222,7 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({
         setCloudError('');
 
         const hasCloudConfig = dropboxClientId.trim() || googleDriveClientId.trim();
-        if (!googleKey.trim() && !replicateKey.trim() && !xaiKey.trim() && !elevenLabsKey.trim() && !sonautoKey.trim() && !falKey.trim() && !ltxKey.trim() && !worldLabsKey.trim() && !braveSearchKey.trim() && !unsplashKey.trim() && !hasCloudConfig) {
+        if (!googleKey.trim() && !replicateKey.trim() && !xaiKey.trim() && !elevenLabsKey.trim() && !sonautoKey.trim() && !soniloKey.trim() && !falKey.trim() && !ltxKey.trim() && !worldLabsKey.trim() && !braveSearchKey.trim() && !unsplashKey.trim() && !hasCloudConfig) {
             setError("Please enter at least one API Key to continue.");
             return;
         }
@@ -252,6 +259,12 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({
             localStorage.setItem('sonauto_api_key', sonautoKey.trim());
         } else {
             localStorage.removeItem('sonauto_api_key');
+        }
+
+        if (soniloKey.trim()) {
+            localStorage.setItem('sonilo_api_key', soniloKey.trim());
+        } else {
+            localStorage.removeItem('sonilo_api_key');
         }
 
         if (falKey.trim()) {
@@ -499,6 +512,38 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({
                                 sonauto.ai/developers
                             </a>
                             . Sonauto notes that user-facing API integrations may require attribution.
+                        </p>
+                    </div>
+
+                    <div className="app-card p-4">
+                        <div className="flex justify-between items-center mb-2">
+                            <label className="block text-xs font-bold app-muted uppercase">Sonilo API</label>
+                            {soniloSaved && <span className="text-[10px] text-emerald-300 flex items-center gap-1"><CheckCircleIcon className="w-3 h-3" /> Saved</span>}
+                        </div>
+                        <div className="relative">
+                            <input
+                                type="password"
+                                value={soniloKey}
+                                onChange={(e) => { setSoniloKey(e.target.value); setSoniloSaved(false); }}
+                                className="app-input pl-10"
+                                placeholder="sk-..."
+                            />
+                            <div className="absolute left-3 top-3.5 app-muted">
+                                <LockIcon className="w-4 h-4" />
+                            </div>
+                        </div>
+                        <p className="text-[10px] app-muted mt-2">Used for the Music node in Node Space: a licensed track generated from a rendered video.</p>
+                        <p className="text-[10px] app-muted mt-1">
+                            Get a key at{' '}
+                            <a
+                                className="text-indigo-300 hover:text-indigo-200"
+                                href="https://platform.sonilo.com/dashboard/api-keys"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                platform.sonilo.com
+                            </a>
+                            . Create an API key and paste it here.
                         </p>
                     </div>
 

--- a/src/services/soniloService.test.ts
+++ b/src/services/soniloService.test.ts
@@ -1,0 +1,201 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createSoniloVideoToMusicClient, SONILO_VIDEO_TO_MUSIC_MODEL } from './soniloService.ts';
+
+const encodeChunk = (text: string) => Buffer.from(text).toString('base64');
+
+const buildNdjson = (lines: Array<Record<string, unknown> | string>) =>
+  lines.map((line) => (typeof line === 'string' ? line : JSON.stringify(line))).join('\n') + '\n';
+
+test('streams a Sonilo video-to-music generation from a video URL into an audio item', async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const usageEntries: unknown[] = [];
+  const capturedBlobs: Blob[] = [];
+  const statuses: string[] = [];
+
+  const ndjson = buildNdjson([
+    { type: 'stage_start', stage: 'analysis' },
+    'not json — must be ignored',
+    { type: 'title', title: 'Neon Skyline' },
+    { type: 'audio_chunk', stream_index: 0, num_streams: 1, data: encodeChunk('AUDIO-PART-1;') },
+    { type: 'audio_chunk', stream_index: 0, num_streams: 1, data: encodeChunk('AUDIO-PART-2') },
+    { type: 'complete' },
+  ]);
+
+  const client = createSoniloVideoToMusicClient({
+    apiKey: 'sonilo_test_key',
+    now: () => 1700000000000,
+    recordUsage: (entry) => {
+      usageEntries.push(entry);
+      return entry as never;
+    },
+    createObjectUrl: (blob) => {
+      capturedBlobs.push(blob);
+      return 'blob:sonilo-audio';
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(ndjson, { status: 200 });
+    },
+  });
+
+  const item = await client.generateMusicFromVideo({
+    videoUrl: 'https://example.com/final_cut.mp4',
+    prompt: 'warm analog synths',
+    onStatus: (message) => statuses.push(message),
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'https://api.sonilo.com/v1/video-to-music');
+  assert.equal(calls[0].init?.method, 'POST');
+  assert.equal((calls[0].init?.headers as Record<string, string>).Authorization, 'Bearer sonilo_test_key');
+
+  const body = calls[0].init?.body as FormData;
+  assert.ok(body instanceof FormData);
+  assert.equal(body.get('video_url'), 'https://example.com/final_cut.mp4');
+  assert.equal(body.get('prompt'), 'warm analog synths');
+  assert.equal(body.get('video'), null);
+
+  assert.equal(capturedBlobs.length, 1);
+  assert.equal(capturedBlobs[0].type, 'audio/mp4');
+  const audioText = Buffer.from(await capturedBlobs[0].arrayBuffer()).toString();
+  assert.equal(audioText, 'AUDIO-PART-1;AUDIO-PART-2');
+
+  assert.equal(item.id, 'sonilo-1700000000000');
+  assert.equal(item.name, 'sonilo_neon_skyline.m4a');
+  assert.equal(item.type, 'audio');
+  assert.equal(item.url, 'blob:sonilo-audio');
+  assert.equal(item.source, 'generated');
+  assert.equal(item.generatedBy, 'Sonilo Video-to-Music');
+  assert.equal(item.prompt, 'warm analog synths');
+
+  assert.deepEqual(usageEntries, [{
+    provider: 'sonilo',
+    model: SONILO_VIDEO_TO_MUSIC_MODEL,
+    kind: 'audio',
+    units: 1,
+    unitLabel: 'clip',
+    note: 'Sonilo video-to-music track',
+  }]);
+
+  assert.ok(statuses.length > 0);
+});
+
+test('uploads local blob/data videos as multipart file input', async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+  const ndjson = buildNdjson([
+    { type: 'audio_chunk', stream_index: 0, num_streams: 1, data: encodeChunk('LOCAL-AUDIO') },
+    { type: 'complete' },
+  ]);
+
+  const client = createSoniloVideoToMusicClient({
+    apiKey: 'sonilo_test_key',
+    recordUsage: () => null,
+    createObjectUrl: () => 'blob:sonilo-audio',
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (String(url).startsWith('blob:')) {
+        return new Response(new Blob(['VIDEO-BYTES'], { type: 'video/mp4' }), { status: 200 });
+      }
+      return new Response(ndjson, { status: 200 });
+    },
+  });
+
+  const item = await client.generateMusicFromVideo({
+    videoUrl: 'blob:local-render',
+    videoName: 'rendered_cut.mp4',
+  });
+
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].url, 'blob:local-render');
+  assert.equal(calls[1].url, 'https://api.sonilo.com/v1/video-to-music');
+
+  const body = calls[1].init?.body as FormData;
+  assert.ok(body instanceof FormData);
+  assert.equal(body.get('video_url'), null);
+  assert.equal(body.get('prompt'), null);
+  const file = body.get('video') as File;
+  assert.ok(file instanceof File);
+  assert.equal(file.name, 'rendered_cut.mp4');
+  assert.equal(Buffer.from(await file.arrayBuffer()).toString(), 'VIDEO-BYTES');
+
+  assert.equal(item.type, 'audio');
+  assert.equal(item.name, 'sonilo_rendered_cut.m4a');
+});
+
+test('fails without an API key before any request is made', async () => {
+  let fetchCalls = 0;
+  const client = createSoniloVideoToMusicClient({
+    apiKey: null,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response('', { status: 200 });
+    },
+  });
+
+  await assert.rejects(
+    client.generateMusicFromVideo({ videoUrl: 'https://example.com/final_cut.mp4' }),
+    /Sonilo API key is missing/,
+  );
+  assert.equal(fetchCalls, 0);
+});
+
+test('maps HTTP errors to clear messages', async () => {
+  const buildClient = (status: number, body: string) =>
+    createSoniloVideoToMusicClient({
+      apiKey: 'sonilo_test_key',
+      fetchImpl: async () => new Response(body, { status }),
+    });
+
+  await assert.rejects(
+    buildClient(401, JSON.stringify({ detail: 'bad key' }))
+      .generateMusicFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /Sonilo API key was rejected/,
+  );
+
+  await assert.rejects(
+    buildClient(422, JSON.stringify({ detail: 'Video too long' }))
+      .generateMusicFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /Sonilo API Error \(422\): Video too long/,
+  );
+
+  await assert.rejects(
+    buildClient(429, JSON.stringify({ detail: 'slow down' }))
+      .generateMusicFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /Sonilo rate limit exceeded: slow down/,
+  );
+});
+
+test('surfaces stream error events and incomplete streams', async () => {
+  const buildClient = (ndjson: string) =>
+    createSoniloVideoToMusicClient({
+      apiKey: 'sonilo_test_key',
+      recordUsage: () => null,
+      createObjectUrl: () => 'blob:sonilo-audio',
+      fetchImpl: async () => new Response(ndjson, { status: 200 }),
+    });
+
+  await assert.rejects(
+    buildClient(buildNdjson([
+      { type: 'audio_chunk', stream_index: 0, num_streams: 1, data: encodeChunk('X') },
+      { type: 'error', message: 'generation failed upstream' },
+    ])).generateMusicFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /generation failed upstream/,
+  );
+
+  await assert.rejects(
+    buildClient(buildNdjson([
+      { type: 'audio_chunk', stream_index: 0, num_streams: 1, data: encodeChunk('X') },
+    ])).generateMusicFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /ended before completing/,
+  );
+
+  await assert.rejects(
+    buildClient(buildNdjson([
+      { type: 'complete' },
+    ])).generateMusicFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /without returning audio data/,
+  );
+});

--- a/src/services/soniloService.test.ts
+++ b/src/services/soniloService.test.ts
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createSoniloVideoToMusicClient, SONILO_VIDEO_TO_MUSIC_MODEL } from './soniloService.ts';
+import {
+  createSoniloVideoToMusicClient,
+  createSoniloVideoToSfxClient,
+  SONILO_VIDEO_TO_MUSIC_MODEL,
+  SONILO_VIDEO_TO_SFX_MODEL,
+} from './soniloService.ts';
 
 const encodeChunk = (text: string) => Buffer.from(text).toString('base64');
 
@@ -198,4 +203,320 @@ test('surfaces stream error events and incomplete streams', async () => {
     ])).generateMusicFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
     /without returning audio data/,
   );
+});
+
+const SFX_SUBMIT_URL = 'https://api.sonilo.com/v1/video-to-sfx';
+const SFX_TASK_URL = 'https://api.sonilo.com/v1/tasks/task_abc12345';
+const SFX_ARTIFACT_URL = 'https://storage.sonilo.example/results/task_abc12345.m4a';
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), { status, headers: { 'Content-Type': 'application/json' } });
+
+test('runs the SFX task pipeline from a video URL into an audio item', async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const usageEntries: unknown[] = [];
+  const capturedBlobs: Blob[] = [];
+  const statuses: string[] = [];
+  const sleeps: number[] = [];
+  let pollCount = 0;
+
+  const client = createSoniloVideoToSfxClient({
+    apiKey: 'sonilo_test_key',
+    now: () => 1700000000000,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+    getDurationSeconds: async () => 42,
+    recordUsage: (entry) => {
+      usageEntries.push(entry);
+      return entry as never;
+    },
+    createObjectUrl: (blob) => {
+      capturedBlobs.push(blob);
+      return 'blob:sonilo-sfx-audio';
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (String(url) === SFX_SUBMIT_URL) {
+        return jsonResponse({ task_id: 'task_abc12345' }, 202);
+      }
+      if (String(url) === SFX_TASK_URL) {
+        pollCount += 1;
+        if (pollCount === 1) {
+          return jsonResponse({ status: 'processing' });
+        }
+        return jsonResponse({
+          status: 'succeeded',
+          audio: { url: SFX_ARTIFACT_URL, content_type: 'audio/mp4', file_size: 12 },
+          video: { url: 'https://storage.sonilo.example/results/task_abc12345.mp4' },
+        });
+      }
+      if (String(url) === SFX_ARTIFACT_URL) {
+        return new Response(new Blob(['SFX-AUDIO'], { type: 'audio/mp4' }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    },
+  });
+
+  const item = await client.generateSfxFromVideo({
+    videoUrl: 'https://example.com/final_cut.mp4',
+    videoName: 'final_cut.mp4',
+    prompt: 'footsteps on gravel, distant traffic',
+    onStatus: (message) => statuses.push(message),
+  });
+
+  assert.deepEqual(calls.map((call) => call.url), [
+    SFX_SUBMIT_URL,
+    SFX_TASK_URL,
+    SFX_TASK_URL,
+    SFX_ARTIFACT_URL,
+  ]);
+  assert.equal(calls[0].init?.method, 'POST');
+  assert.equal((calls[0].init?.headers as Record<string, string>).Authorization, 'Bearer sonilo_test_key');
+  assert.equal((calls[1].init?.headers as Record<string, string>).Authorization, 'Bearer sonilo_test_key');
+
+  // The artifact URL is presigned: the API key must never reach the storage domain.
+  const artifactCall = calls[3];
+  const artifactHeaders = (artifactCall.init?.headers || {}) as Record<string, string>;
+  assert.equal(artifactHeaders.Authorization, undefined);
+
+  const body = calls[0].init?.body as FormData;
+  assert.ok(body instanceof FormData);
+  assert.equal(body.get('video_url'), 'https://example.com/final_cut.mp4');
+  assert.equal(body.get('prompt'), 'footsteps on gravel, distant traffic');
+  assert.equal(body.get('video'), null);
+
+  assert.deepEqual(sleeps, [5000]);
+
+  assert.equal(capturedBlobs.length, 1);
+  assert.equal(capturedBlobs[0].type, 'audio/mp4');
+  assert.equal(Buffer.from(await capturedBlobs[0].arrayBuffer()).toString(), 'SFX-AUDIO');
+
+  assert.equal(item.id, 'sonilo-sfx-1700000000000');
+  assert.equal(item.name, 'sonilo_sfx_final_cut.m4a');
+  assert.equal(item.type, 'audio');
+  assert.equal(item.url, 'blob:sonilo-sfx-audio');
+  assert.equal(item.source, 'generated');
+  assert.equal(item.generatedBy, 'Sonilo Video-to-SFX');
+  assert.equal(item.prompt, 'footsteps on gravel, distant traffic');
+
+  assert.deepEqual(usageEntries, [{
+    provider: 'sonilo',
+    model: SONILO_VIDEO_TO_SFX_MODEL,
+    kind: 'audio',
+    units: 1,
+    unitLabel: 'clip',
+    note: 'Sonilo video-to-sfx audio',
+  }]);
+
+  assert.ok(statuses.length > 0);
+});
+
+test('uploads local blob/data videos to the SFX endpoint as multipart file input', async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+  const client = createSoniloVideoToSfxClient({
+    apiKey: 'sonilo_test_key',
+    sleep: async () => {},
+    getDurationSeconds: async () => {
+      throw new Error('duration probe unavailable');
+    },
+    recordUsage: () => null,
+    createObjectUrl: () => 'blob:sonilo-sfx-audio',
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (String(url).startsWith('blob:')) {
+        return new Response(new Blob(['VIDEO-BYTES'], { type: 'video/mp4' }), { status: 200 });
+      }
+      if (String(url) === SFX_SUBMIT_URL) {
+        return jsonResponse({ task_id: 'task_abc12345' }, 202);
+      }
+      if (String(url) === SFX_TASK_URL) {
+        return jsonResponse({
+          status: 'succeeded',
+          audio: { url: SFX_ARTIFACT_URL, content_type: 'audio/wav' },
+        });
+      }
+      return new Response(new Blob(['WAV-AUDIO'], { type: 'audio/wav' }), { status: 200 });
+    },
+  });
+
+  const item = await client.generateSfxFromVideo({
+    videoUrl: 'blob:local-render',
+    videoName: 'rendered_cut.mp4',
+  });
+
+  assert.equal(calls[0].url, 'blob:local-render');
+  assert.equal(calls[1].url, SFX_SUBMIT_URL);
+
+  const body = calls[1].init?.body as FormData;
+  assert.ok(body instanceof FormData);
+  assert.equal(body.get('video_url'), null);
+  assert.equal(body.get('prompt'), null);
+  const file = body.get('video') as File;
+  assert.ok(file instanceof File);
+  assert.equal(file.name, 'rendered_cut.mp4');
+  assert.equal(Buffer.from(await file.arrayBuffer()).toString(), 'VIDEO-BYTES');
+
+  assert.equal(item.type, 'audio');
+  assert.equal(item.name, 'sonilo_sfx_rendered_cut.wav');
+});
+
+test('SFX fails without an API key before any request is made', async () => {
+  let fetchCalls = 0;
+  const client = createSoniloVideoToSfxClient({
+    apiKey: null,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response('', { status: 200 });
+    },
+  });
+
+  await assert.rejects(
+    client.generateSfxFromVideo({ videoUrl: 'https://example.com/final_cut.mp4' }),
+    /Sonilo API key is missing/,
+  );
+  assert.equal(fetchCalls, 0);
+});
+
+test('SFX pre-checks the 3-minute video limit before submitting', async () => {
+  let fetchCalls = 0;
+  const client = createSoniloVideoToSfxClient({
+    apiKey: 'sonilo_test_key',
+    getDurationSeconds: async () => 200,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response('', { status: 200 });
+    },
+  });
+
+  await assert.rejects(
+    client.generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /up to 180 seconds/,
+  );
+  assert.equal(fetchCalls, 0);
+});
+
+test('SFX lets the backend decide when the duration probe fails', async () => {
+  let submitCalls = 0;
+  const client = createSoniloVideoToSfxClient({
+    apiKey: 'sonilo_test_key',
+    getDurationSeconds: async () => {
+      throw new Error('no metadata');
+    },
+    fetchImpl: async () => {
+      submitCalls += 1;
+      return jsonResponse({ detail: 'Video too long' }, 422);
+    },
+  });
+
+  await assert.rejects(
+    client.generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /Sonilo API Error \(422\): Video too long/,
+  );
+  assert.equal(submitCalls, 1);
+});
+
+test('maps SFX submit errors and missing task ids to clear messages', async () => {
+  const buildClient = (respond: () => Response) =>
+    createSoniloVideoToSfxClient({
+      apiKey: 'sonilo_test_key',
+      getDurationSeconds: async () => 30,
+      fetchImpl: async () => respond(),
+    });
+
+  await assert.rejects(
+    buildClient(() => jsonResponse({ detail: 'bad key' }, 401))
+      .generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /Sonilo API key was rejected/,
+  );
+
+  await assert.rejects(
+    buildClient(() => jsonResponse({ detail: 'slow down' }, 429))
+      .generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /Sonilo rate limit exceeded: slow down/,
+  );
+
+  await assert.rejects(
+    buildClient(() => jsonResponse({ ok: true }, 202))
+      .generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /returned no task id/,
+  );
+});
+
+test('maps SFX task polling outcomes to clear messages', async () => {
+  const buildClient = (pollRespond: (pollCount: number) => Response) => {
+    let pollCount = 0;
+    return createSoniloVideoToSfxClient({
+      apiKey: 'sonilo_test_key',
+      sleep: async () => {},
+      getDurationSeconds: async () => 30,
+      recordUsage: () => null,
+      createObjectUrl: () => 'blob:sonilo-sfx-audio',
+      fetchImpl: async (url) => {
+        if (String(url) === SFX_SUBMIT_URL) {
+          return jsonResponse({ task_id: 'task_abc12345' }, 202);
+        }
+        pollCount += 1;
+        return pollRespond(pollCount);
+      },
+    });
+  };
+
+  // 404 means the task id itself is unknown to /v1/tasks (bad id, or a music
+  // generation id) — retrying the same id can never help.
+  await assert.rejects(
+    buildClient(() => jsonResponse({ detail: 'not found' }, 404))
+      .generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /task task_abc12345 was not found/,
+  );
+
+  // Any other polling error keeps the task id in the message: the task was
+  // already accepted and may still finish on the backend.
+  await assert.rejects(
+    buildClient(() => jsonResponse({ detail: 'backend hiccup' }, 500))
+      .generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /Sonilo API Error \(500\): backend hiccup.*task_abc12345/,
+  );
+
+  await assert.rejects(
+    buildClient(() => jsonResponse({
+      status: 'failed',
+      error: { code: 'GEN_FAILED', message: 'model rejected the input' },
+      refunded: true,
+    })).generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /failed \(GEN_FAILED\): model rejected the input\. The charge was reversed\./,
+  );
+
+  await assert.rejects(
+    buildClient(() => jsonResponse({
+      status: 'succeeded',
+      audio: {},
+    })).generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /succeeded but returned no audio artifact/,
+  );
+});
+
+test('SFX polling timeout keeps the task id in the message', async () => {
+  const sleeps: number[] = [];
+  const client = createSoniloVideoToSfxClient({
+    apiKey: 'sonilo_test_key',
+    pollTimeoutMs: 0,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+    getDurationSeconds: async () => 30,
+    fetchImpl: async (url) => {
+      if (String(url) === SFX_SUBMIT_URL) {
+        return jsonResponse({ task_id: 'task_abc12345' }, 202);
+      }
+      return jsonResponse({ status: 'processing' });
+    },
+  });
+
+  await assert.rejects(
+    client.generateSfxFromVideo({ videoUrl: 'https://example.com/a.mp4' }),
+    /timed out waiting for SFX task task_abc12345.*may still complete/,
+  );
+  assert.equal(sleeps.length, 0);
 });

--- a/src/services/soniloService.ts
+++ b/src/services/soniloService.ts
@@ -1,0 +1,315 @@
+import type { MediaItem, UsageEntry } from '../types';
+
+export const SONILO_API_BASE_URL = 'https://api.sonilo.com';
+export const SONILO_VIDEO_TO_MUSIC_PATH = '/v1/video-to-music';
+export const SONILO_VIDEO_TO_MUSIC_MODEL = 'video-to-music';
+export const SONILO_API_KEY_STORAGE_KEY = 'sonilo_api_key';
+export const SONILO_API_KEYS_URL = 'https://platform.sonilo.com/dashboard/api-keys';
+
+// The backend rejects videos longer than 6 minutes; surfaced here so UI copy
+// can reference the same limit.
+export const SONILO_MAX_VIDEO_DURATION_SECONDS = 360;
+
+type SoniloStreamEvent = {
+  type?: string;
+  data?: string;
+  stream_index?: number;
+  num_streams?: number;
+  title?: string;
+  message?: string;
+  code?: string;
+};
+
+type UsageInput = Omit<UsageEntry, 'id' | 'createdAt'> & Partial<Pick<UsageEntry, 'id' | 'createdAt'>>;
+
+type SoniloClientDeps = {
+  apiKey?: string | null;
+  baseUrl?: string;
+  fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>;
+  now?: () => number;
+  recordUsage?: (entry: UsageInput) => unknown;
+  createObjectUrl?: (blob: Blob) => string;
+};
+
+export type SoniloVideoToMusicInput = {
+  /** HTTPS URL, blob: URL, or data: URI of the rendered video. */
+  videoUrl: string;
+  /** Original video name, used to label the generated track. */
+  videoName?: string;
+  /** Optional single style hint for the whole track. */
+  prompt?: string;
+  onStatus?: (message: string) => void;
+};
+
+const getDefaultFetch = () => {
+  if (typeof fetch === 'undefined') {
+    throw new Error('Fetch API is not available in this runtime.');
+  }
+  return fetch.bind(globalThis);
+};
+
+export const getSoniloApiKeyOptional = () => {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(SONILO_API_KEY_STORAGE_KEY);
+};
+
+export const hasSoniloApiKey = () => Boolean(getSoniloApiKeyOptional());
+
+const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/+$/, '');
+
+const sanitizeNameSegment = (value?: string) => {
+  const raw = (value || '').replace(/\.[a-z0-9]+$/i, '');
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 80);
+};
+
+const readErrorDetail = async (response: Response) => {
+  const text = await response.text().catch(() => '');
+  if (!text) return response.statusText;
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === 'object') {
+      const detail = parsed.detail || parsed.error || parsed.message;
+      if (typeof detail === 'string' && detail.trim()) return detail.trim();
+    }
+    return text;
+  } catch {
+    return text;
+  }
+};
+
+const buildHttpError = (status: number, detail: string) => {
+  if (status === 401) {
+    return new Error(`Sonilo API key was rejected. Verify the key in Settings (${SONILO_API_KEYS_URL}).`);
+  }
+  if (status === 402) {
+    return new Error(detail || 'Sonilo account has no remaining credits.');
+  }
+  if (status === 413) {
+    return new Error(`Sonilo upload is too large: ${detail}`);
+  }
+  if (status === 429) {
+    return new Error(`Sonilo rate limit exceeded: ${detail}`);
+  }
+  return new Error(`Sonilo API Error (${status}): ${detail}`);
+};
+
+const decodeBase64Chunk = (data: string): Uint8Array | null => {
+  try {
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+};
+
+const concatChunks = (chunks: Uint8Array[]) => {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged;
+};
+
+type ConsumedStream = {
+  audioBytes: Uint8Array;
+  title: string | null;
+};
+
+/**
+ * Consume the NDJSON event stream returned by Sonilo generation endpoints.
+ *
+ * Event types: `audio_chunk` (base64 audio bytes per stream_index), `title`,
+ * `complete` (terminal success), `error` (terminal failure). Progress events
+ * such as `stage_start`/`stage_complete` and malformed lines are ignored.
+ */
+const consumeNdjsonStream = async (response: Response): Promise<ConsumedStream> => {
+  const body = response.body;
+  if (!body) {
+    throw new Error('Sonilo returned an empty response stream.');
+  }
+
+  const streams = new Map<number, Uint8Array[]>();
+  let title: string | null = null;
+  let completed = false;
+  let errorMessage: string | null = null;
+
+  const handleLine = (line: string) => {
+    if (!line.trim()) return;
+    let event: SoniloStreamEvent;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (!event || typeof event !== 'object') return;
+    if (event.type === 'audio_chunk') {
+      const index = Number.isInteger(event.stream_index) ? Number(event.stream_index) : 0;
+      if (index < 0 || typeof event.data !== 'string') return;
+      const decoded = decodeBase64Chunk(event.data);
+      if (!decoded) return;
+      const chunks = streams.get(index) || [];
+      chunks.push(decoded);
+      streams.set(index, chunks);
+    } else if (event.type === 'title') {
+      if (typeof event.title === 'string' && event.title.trim()) {
+        title = event.title.trim();
+      }
+    } else if (event.type === 'complete') {
+      completed = true;
+    } else if (event.type === 'error') {
+      errorMessage = event.message || event.code || 'Sonilo stream error.';
+    }
+  };
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (!errorMessage) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let newlineIndex = buffer.indexOf('\n');
+    while (newlineIndex >= 0) {
+      handleLine(buffer.slice(0, newlineIndex));
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf('\n');
+    }
+  }
+  if (!errorMessage && buffer.trim()) {
+    handleLine(buffer);
+  }
+
+  if (errorMessage) {
+    throw new Error(errorMessage);
+  }
+  if (!completed) {
+    throw new Error('Sonilo stream ended before completing. Please try again.');
+  }
+
+  const firstIndex = [...streams.keys()].sort((a, b) => a - b)[0];
+  const chunks = firstIndex === undefined ? [] : streams.get(firstIndex) || [];
+  if (chunks.length === 0) {
+    throw new Error('Sonilo finished without returning audio data.');
+  }
+  return { audioBytes: concatChunks(chunks), title };
+};
+
+export const createSoniloVideoToMusicClient = (deps: SoniloClientDeps = {}) => {
+  const baseUrl = normalizeBaseUrl(deps.baseUrl || SONILO_API_BASE_URL);
+  const fetchImpl = deps.fetchImpl || getDefaultFetch();
+  const now = deps.now || (() => Date.now());
+  const createObjectUrl = deps.createObjectUrl || ((blob: Blob) => URL.createObjectURL(blob));
+
+  const resolveApiKey = () => {
+    if (deps.apiKey !== undefined) return deps.apiKey?.trim() || null;
+    return getSoniloApiKeyOptional()?.trim() || null;
+  };
+
+  const buildRequestBody = async (input: SoniloVideoToMusicInput) => {
+    const videoUrl = input.videoUrl.trim();
+    if (!videoUrl) {
+      throw new Error('Sonilo needs a video input.');
+    }
+    const form = new FormData();
+    if (/^https?:\/\//i.test(videoUrl)) {
+      // Remote videos are passed by URL so the backend fetches them directly.
+      form.append('video_url', videoUrl);
+    } else {
+      // blob:/data: sources only exist locally, so upload the bytes.
+      const response = await fetchImpl(videoUrl);
+      if (!response.ok) {
+        throw new Error(`Could not read the input video (${response.status}).`);
+      }
+      const blob = await response.blob();
+      const fileName = input.videoName?.trim() || 'video.mp4';
+      form.append('video', new File([blob], fileName, { type: blob.type || 'video/mp4' }));
+    }
+    const prompt = input.prompt?.trim();
+    if (prompt) {
+      form.append('prompt', prompt);
+    }
+    return form;
+  };
+
+  const generateMusicFromVideo = async (input: SoniloVideoToMusicInput): Promise<MediaItem> => {
+    const key = resolveApiKey();
+    if (!key) {
+      throw new Error('Sonilo API key is missing. Add it in Settings.');
+    }
+
+    const form = await buildRequestBody(input);
+    input.onStatus?.('Sonilo: composing a track from the video...');
+
+    const response = await fetchImpl(`${baseUrl}${SONILO_VIDEO_TO_MUSIC_PATH}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${key}`,
+      },
+      body: form,
+    });
+
+    if (!response.ok) {
+      throw buildHttpError(response.status, await readErrorDetail(response));
+    }
+
+    input.onStatus?.('Sonilo: receiving audio...');
+    const { audioBytes, title } = await consumeNdjsonStream(response);
+
+    // The backend streams AAC audio in an MP4 container (.m4a). The merged
+    // buffer is exactly sized in concatChunks, so it is safe to hand over.
+    const audioBlob = new Blob([audioBytes.buffer as ArrayBuffer], { type: 'audio/mp4' });
+    const audioUrl = createObjectUrl(audioBlob);
+
+    let duration: number | undefined;
+    try {
+      const { getVideoDuration } = await import('../utils/helpers');
+      duration = await getVideoDuration(audioUrl);
+    } catch {
+      duration = undefined;
+    }
+
+    const usage: UsageInput = {
+      provider: 'sonilo',
+      model: SONILO_VIDEO_TO_MUSIC_MODEL,
+      kind: 'audio',
+      units: 1,
+      unitLabel: 'clip',
+      note: 'Sonilo video-to-music track',
+    };
+    if (deps.recordUsage) {
+      deps.recordUsage(usage);
+    } else {
+      const mod = await import('../utils/usageTracker');
+      mod.recordUsage(usage);
+    }
+
+    const nameBase = sanitizeNameSegment(title || input.videoName) || `track_${now()}`;
+    return {
+      id: `sonilo-${now()}`,
+      name: `sonilo_${nameBase}.m4a`,
+      type: 'audio',
+      url: audioUrl,
+      source: 'generated',
+      generatedBy: 'Sonilo Video-to-Music',
+      prompt: input.prompt?.trim() || undefined,
+      duration,
+    };
+  };
+
+  return { generateMusicFromVideo };
+};
+
+export const generateMusicFromVideoWithSonilo = (input: SoniloVideoToMusicInput) =>
+  createSoniloVideoToMusicClient().generateMusicFromVideo(input);

--- a/src/services/soniloService.ts
+++ b/src/services/soniloService.ts
@@ -3,12 +3,23 @@ import type { MediaItem, UsageEntry } from '../types';
 export const SONILO_API_BASE_URL = 'https://api.sonilo.com';
 export const SONILO_VIDEO_TO_MUSIC_PATH = '/v1/video-to-music';
 export const SONILO_VIDEO_TO_MUSIC_MODEL = 'video-to-music';
+export const SONILO_VIDEO_TO_SFX_PATH = '/v1/video-to-sfx';
+export const SONILO_TASKS_PATH = '/v1/tasks';
+export const SONILO_VIDEO_TO_SFX_MODEL = 'video-to-sfx';
 export const SONILO_API_KEY_STORAGE_KEY = 'sonilo_api_key';
 export const SONILO_API_KEYS_URL = 'https://platform.sonilo.com/dashboard/api-keys';
 
 // The backend rejects videos longer than 6 minutes; surfaced here so UI copy
 // can reference the same limit.
 export const SONILO_MAX_VIDEO_DURATION_SECONDS = 360;
+
+// The SFX endpoint accepts shorter videos than the music endpoint.
+export const SONILO_SFX_MAX_VIDEO_DURATION_SECONDS = 180;
+
+// Task polling cadence for the async SFX pipeline. The backend keeps working
+// after a local timeout, so the timeout message carries the task id.
+export const SONILO_TASK_POLL_INTERVAL_MS = 5_000;
+export const SONILO_TASK_POLL_TIMEOUT_MS = 10 * 60 * 1_000;
 
 type SoniloStreamEvent = {
   type?: string;
@@ -39,6 +50,44 @@ export type SoniloVideoToMusicInput = {
   /** Optional single style hint for the whole track. */
   prompt?: string;
   onStatus?: (message: string) => void;
+};
+
+export type SoniloVideoToSfxInput = {
+  /** HTTPS URL, blob: URL, or data: URI of the rendered video. */
+  videoUrl: string;
+  /** Original video name, used to label the generated audio. */
+  videoName?: string;
+  /** Optional description of the desired sound effects. */
+  prompt?: string;
+  onStatus?: (message: string) => void;
+};
+
+type SoniloSfxClientDeps = SoniloClientDeps & {
+  /** Milliseconds between task status polls. */
+  pollIntervalMs?: number;
+  /** Overall budget for waiting on the task before giving up locally. */
+  pollTimeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Best-effort probe of the input video's duration in seconds, used to
+   * fail fast before uploading a video the backend will reject. Errors from
+   * the probe are ignored and the backend makes the final call.
+   */
+  getDurationSeconds?: (videoUrl: string) => Promise<number>;
+};
+
+type SoniloTaskArtifact = {
+  url?: string;
+  content_type?: string;
+  file_size?: number;
+};
+
+type SoniloTaskBody = {
+  status?: string;
+  audio?: SoniloTaskArtifact;
+  video?: SoniloTaskArtifact;
+  error?: { code?: string; message?: string } | string;
+  refunded?: boolean;
 };
 
 const getDefaultFetch = () => {
@@ -96,6 +145,40 @@ const buildHttpError = (status: number, detail: string) => {
     return new Error(`Sonilo rate limit exceeded: ${detail}`);
   }
   return new Error(`Sonilo API Error (${status}): ${detail}`);
+};
+
+type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Build the multipart body shared by the Sonilo video endpoints: remote
+ * HTTPS videos are passed by URL so the backend fetches them directly,
+ * while blob:/data: sources only exist locally and are uploaded as bytes.
+ */
+const buildVideoFormData = async (
+  fetchImpl: FetchLike,
+  input: { videoUrl: string; videoName?: string; prompt?: string },
+): Promise<FormData> => {
+  const videoUrl = input.videoUrl.trim();
+  if (!videoUrl) {
+    throw new Error('Sonilo needs a video input.');
+  }
+  const form = new FormData();
+  if (/^https?:\/\//i.test(videoUrl)) {
+    form.append('video_url', videoUrl);
+  } else {
+    const response = await fetchImpl(videoUrl);
+    if (!response.ok) {
+      throw new Error(`Could not read the input video (${response.status}).`);
+    }
+    const blob = await response.blob();
+    const fileName = input.videoName?.trim() || 'video.mp4';
+    form.append('video', new File([blob], fileName, { type: blob.type || 'video/mp4' }));
+  }
+  const prompt = input.prompt?.trim();
+  if (prompt) {
+    form.append('prompt', prompt);
+  }
+  return form;
 };
 
 const decodeBase64Chunk = (data: string): Uint8Array | null => {
@@ -217,39 +300,13 @@ export const createSoniloVideoToMusicClient = (deps: SoniloClientDeps = {}) => {
     return getSoniloApiKeyOptional()?.trim() || null;
   };
 
-  const buildRequestBody = async (input: SoniloVideoToMusicInput) => {
-    const videoUrl = input.videoUrl.trim();
-    if (!videoUrl) {
-      throw new Error('Sonilo needs a video input.');
-    }
-    const form = new FormData();
-    if (/^https?:\/\//i.test(videoUrl)) {
-      // Remote videos are passed by URL so the backend fetches them directly.
-      form.append('video_url', videoUrl);
-    } else {
-      // blob:/data: sources only exist locally, so upload the bytes.
-      const response = await fetchImpl(videoUrl);
-      if (!response.ok) {
-        throw new Error(`Could not read the input video (${response.status}).`);
-      }
-      const blob = await response.blob();
-      const fileName = input.videoName?.trim() || 'video.mp4';
-      form.append('video', new File([blob], fileName, { type: blob.type || 'video/mp4' }));
-    }
-    const prompt = input.prompt?.trim();
-    if (prompt) {
-      form.append('prompt', prompt);
-    }
-    return form;
-  };
-
   const generateMusicFromVideo = async (input: SoniloVideoToMusicInput): Promise<MediaItem> => {
     const key = resolveApiKey();
     if (!key) {
       throw new Error('Sonilo API key is missing. Add it in Settings.');
     }
 
-    const form = await buildRequestBody(input);
+    const form = await buildVideoFormData(fetchImpl, input);
     input.onStatus?.('Sonilo: composing a track from the video...');
 
     const response = await fetchImpl(`${baseUrl}${SONILO_VIDEO_TO_MUSIC_PATH}`, {
@@ -313,3 +370,218 @@ export const createSoniloVideoToMusicClient = (deps: SoniloClientDeps = {}) => {
 
 export const generateMusicFromVideoWithSonilo = (input: SoniloVideoToMusicInput) =>
   createSoniloVideoToMusicClient().generateMusicFromVideo(input);
+
+// content_type -> file extension for SFX audio artifacts. The backend sets
+// content_type from the requested audio format; the default is AAC (.m4a).
+const SFX_AUDIO_EXTENSIONS: Record<string, string> = {
+  'audio/wav': '.wav',
+  'audio/mpeg': '.mp3',
+  'audio/mp4': '.m4a',
+  'audio/flac': '.flac',
+};
+
+const sfxExtensionFromContentType = (contentType?: string) => {
+  if (typeof contentType !== 'string') return '.m4a';
+  return SFX_AUDIO_EXTENSIONS[contentType.toLowerCase().split(';')[0].trim()] || '.m4a';
+};
+
+const defaultGetDurationSeconds = async (videoUrl: string) => {
+  const { getVideoDuration } = await import('../utils/helpers');
+  return getVideoDuration(videoUrl);
+};
+
+const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Client for the Sonilo SFX task pipeline. Unlike the streaming music
+ * endpoint, `/v1/video-to-sfx` is asynchronous: the POST returns a task id,
+ * `/v1/tasks/{task_id}` is polled until the task is terminal, and the audio
+ * artifact is then downloaded from a presigned URL. Presigned result URLs
+ * carry their own auth, so the API key is only ever sent to the Sonilo API
+ * host, never to the storage domain.
+ */
+export const createSoniloVideoToSfxClient = (deps: SoniloSfxClientDeps = {}) => {
+  const baseUrl = normalizeBaseUrl(deps.baseUrl || SONILO_API_BASE_URL);
+  const fetchImpl = deps.fetchImpl || getDefaultFetch();
+  const now = deps.now || (() => Date.now());
+  const createObjectUrl = deps.createObjectUrl || ((blob: Blob) => URL.createObjectURL(blob));
+  const pollIntervalMs = deps.pollIntervalMs ?? SONILO_TASK_POLL_INTERVAL_MS;
+  const pollTimeoutMs = deps.pollTimeoutMs ?? SONILO_TASK_POLL_TIMEOUT_MS;
+  const sleep = deps.sleep || defaultSleep;
+  const getDurationSeconds = deps.getDurationSeconds || defaultGetDurationSeconds;
+
+  const resolveApiKey = () => {
+    if (deps.apiKey !== undefined) return deps.apiKey?.trim() || null;
+    return getSoniloApiKeyOptional()?.trim() || null;
+  };
+
+  // Best-effort pre-check so an over-length video fails before the upload.
+  // If the duration cannot be read locally, the backend makes the final call.
+  const checkVideoDuration = async (videoUrl: string) => {
+    let duration: number;
+    try {
+      duration = await getDurationSeconds(videoUrl);
+    } catch {
+      return;
+    }
+    if (Number.isFinite(duration) && duration > SONILO_SFX_MAX_VIDEO_DURATION_SECONDS) {
+      throw new Error(
+        `Sonilo SFX supports videos up to ${SONILO_SFX_MAX_VIDEO_DURATION_SECONDS} seconds (3 minutes); this video is ${Math.round(duration)}s.`,
+      );
+    }
+  };
+
+  const submitTask = async (form: FormData, key: string): Promise<string> => {
+    const response = await fetchImpl(`${baseUrl}${SONILO_VIDEO_TO_SFX_PATH}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${key}`,
+      },
+      body: form,
+    });
+    if (!response.ok) {
+      throw buildHttpError(response.status, await readErrorDetail(response));
+    }
+    let payload: unknown = null;
+    try {
+      payload = await response.json();
+    } catch {
+      payload = null;
+    }
+    const taskId = payload && typeof payload === 'object' ? (payload as { task_id?: unknown }).task_id : undefined;
+    if (!taskId || (typeof taskId !== 'string' && typeof taskId !== 'number')) {
+      throw new Error('Sonilo accepted the request but returned no task id.');
+    }
+    return String(taskId);
+  };
+
+  const pollTask = async (taskId: string, key: string): Promise<SoniloTaskBody> => {
+    const deadline = now() + pollTimeoutMs;
+    for (;;) {
+      const response = await fetchImpl(`${baseUrl}${SONILO_TASKS_PATH}/${encodeURIComponent(taskId)}`, {
+        headers: {
+          Authorization: `Bearer ${key}`,
+        },
+      });
+      if (response.status === 404) {
+        // Task status is available for SFX tasks only; a 404 means the id
+        // is wrong (or belongs to a music generation) and retrying the same
+        // id can never help.
+        throw new Error(`Sonilo task ${taskId} was not found. Check that the id belongs to an SFX generation.`);
+      }
+      if (!response.ok) {
+        // The task was already accepted; the id stays valid, so surface it
+        // for recovery once the underlying issue is resolved.
+        const base = buildHttpError(response.status, await readErrorDetail(response));
+        throw new Error(`${base.message} Sonilo task ${taskId} was already submitted and may still finish on the backend.`);
+      }
+      let body: SoniloTaskBody | null = null;
+      try {
+        body = (await response.json()) as SoniloTaskBody;
+      } catch {
+        body = null;
+      }
+      if (!body || typeof body !== 'object') {
+        throw new Error(`Sonilo returned an unexpected task status response for task ${taskId}.`);
+      }
+      if (body.status === 'succeeded' || body.status === 'failed') {
+        return body;
+      }
+      if (now() >= deadline) {
+        throw new Error(
+          `Sonilo timed out waiting for SFX task ${taskId}. The generation may still complete on the backend; run the node again in a little while.`,
+        );
+      }
+      await sleep(pollIntervalMs);
+    }
+  };
+
+  const downloadAudioArtifact = async (taskId: string, audio: SoniloTaskArtifact) => {
+    // Presigned URL: intentionally no Authorization header — the API key
+    // must never be sent to the storage domain.
+    const response = await fetchImpl(audio.url as string);
+    if (!response.ok) {
+      throw new Error(
+        `Could not download the generated audio (${response.status}). The result for Sonilo task ${taskId} is still stored on the backend.`,
+      );
+    }
+    const blob = await response.blob();
+    const contentType = typeof audio.content_type === 'string' && audio.content_type
+      ? audio.content_type
+      : blob.type || 'audio/mp4';
+    return { blob: new Blob([blob], { type: contentType }), extension: sfxExtensionFromContentType(contentType) };
+  };
+
+  const generateSfxFromVideo = async (input: SoniloVideoToSfxInput): Promise<MediaItem> => {
+    const key = resolveApiKey();
+    if (!key) {
+      throw new Error('Sonilo API key is missing. Add it in Settings.');
+    }
+
+    await checkVideoDuration(input.videoUrl.trim());
+
+    const form = await buildVideoFormData(fetchImpl, input);
+    input.onStatus?.('Sonilo: creating sound effects from the video...');
+    const taskId = await submitTask(form, key);
+
+    input.onStatus?.('Sonilo: sound effects in progress...');
+    const body = await pollTask(taskId, key);
+
+    if (body.status === 'failed') {
+      const err = body.error;
+      const code = (typeof err === 'object' && err?.code) || 'GENERATION_FAILED';
+      const message = (typeof err === 'object' ? err?.message : typeof err === 'string' ? err : undefined) || 'Generation failed';
+      const refundNote = body.refunded === true ? ' The charge was reversed.' : '';
+      throw new Error(`Sonilo SFX generation failed (${code}): ${message}.${refundNote}`);
+    }
+
+    const audio = body.audio;
+    if (!audio || typeof audio !== 'object' || !audio.url) {
+      throw new Error(`Sonilo task ${taskId} succeeded but returned no audio artifact.`);
+    }
+
+    input.onStatus?.('Sonilo: downloading audio...');
+    const { blob: audioBlob, extension } = await downloadAudioArtifact(taskId, audio);
+    const audioUrl = createObjectUrl(audioBlob);
+
+    let duration: number | undefined;
+    try {
+      const { getVideoDuration } = await import('../utils/helpers');
+      duration = await getVideoDuration(audioUrl);
+    } catch {
+      duration = undefined;
+    }
+
+    const usage: UsageInput = {
+      provider: 'sonilo',
+      model: SONILO_VIDEO_TO_SFX_MODEL,
+      kind: 'audio',
+      units: 1,
+      unitLabel: 'clip',
+      note: 'Sonilo video-to-sfx audio',
+    };
+    if (deps.recordUsage) {
+      deps.recordUsage(usage);
+    } else {
+      const mod = await import('../utils/usageTracker');
+      mod.recordUsage(usage);
+    }
+
+    const nameBase = sanitizeNameSegment(input.videoName) || `task_${taskId.slice(0, 8)}`;
+    return {
+      id: `sonilo-sfx-${now()}`,
+      name: `sonilo_sfx_${nameBase}${extension}`,
+      type: 'audio',
+      url: audioUrl,
+      source: 'generated',
+      generatedBy: 'Sonilo Video-to-SFX',
+      prompt: input.prompt?.trim() || undefined,
+      duration,
+    };
+  };
+
+  return { generateSfxFromVideo };
+};
+
+export const generateSfxFromVideoWithSonilo = (input: SoniloVideoToSfxInput) =>
+  createSoniloVideoToSfxClient().generateSfxFromVideo(input);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1702,7 +1702,7 @@ export type ShotAnnotation = {
   updatedAt?: string;
 };
 
-export type UsageProvider = 'gemini' | 'replicate' | 'fal' | 'ltx' | 'elevenlabs' | 'worldlabs' | 'xai' | 'sonauto' | 'local';
+export type UsageProvider = 'gemini' | 'replicate' | 'fal' | 'ltx' | 'elevenlabs' | 'worldlabs' | 'xai' | 'sonauto' | 'sonilo' | 'local';
 export type UsageKind = 'image' | 'video' | 'audio' | 'edit' | 'analysis' | '3d-world' | 'other';
 export type UsageUnit = 'image' | 'second' | 'minute' | 'request' | 'clip' | 'stem';
 

--- a/src/workspaces/NodeWorkspace.tsx
+++ b/src/workspaces/NodeWorkspace.tsx
@@ -71,6 +71,7 @@ import {
   upscaleVideoWithTopaz,
 } from '../services/replicateService';
 import { generateImageWithFalGrokImagine, generateImageWithFalQwenImageMax } from '../services/falAiService';
+import { generateMusicFromVideoWithSonilo, hasSoniloApiKey } from '../services/soniloService';
 import { getBase64FromUrl } from '../utils/helpers';
 import { FILM_LUTS, buildFilterString, getBloomStrength, getGrainStrength, getHalationStrength, getVignetteStrength, normalizeFilters } from '../utils/colorGrading';
 import { applyCubeLutToImageData, parseCubeLut } from '../utils/lut';
@@ -93,7 +94,8 @@ type NodeKind =
   | 'depth'
   | 'faceRestore'
   | 'bgRemove'
-  | 'rife';
+  | 'rife'
+  | 'music';
 
 type NodeData = {
   label: string;
@@ -881,6 +883,54 @@ const RifeNode: React.FC<NodeProps<NodeData>> = () => {
   );
 };
 
+const MusicNode: React.FC<NodeProps<NodeData>> = ({ data }) => {
+  const previewUrl = data.params?.previewUrl as string | undefined;
+  const keyReady = hasSoniloApiKey();
+  return (
+    <div className="bg-gray-900 border border-pink-500/40 rounded-lg p-3 min-w-[220px] text-gray-200">
+      <div className="text-xs uppercase tracking-[0.2em] text-pink-300">Music</div>
+      <select
+        value={data.selected || ''}
+        onChange={(event) => data.onChange?.({ selected: event.target.value })}
+        className="mt-2 w-full bg-gray-800 text-white text-xs p-2 rounded border border-gray-700 focus:border-pink-500"
+      >
+        {(data.options || ['Sonilo Video-to-Music']).map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+      <textarea
+        value={data.value || ''}
+        placeholder="Style hint (optional)..."
+        className="mt-2 w-full bg-gray-800 text-white text-xs p-2 rounded border border-gray-700 focus:border-pink-500"
+        rows={2}
+        onChange={(event) => data.onChange?.({ value: event.target.value })}
+      />
+      <div className="mt-2 text-[10px] text-gray-500">
+        Composes an original track matched to the input video (max 6 min).
+      </div>
+      {!keyReady && (
+        <div className="mt-2 text-[10px] text-amber-300">
+          Add a Sonilo API key in Settings to run this node.
+        </div>
+      )}
+      <div className="mt-2 rounded border border-dashed border-gray-700 p-2">
+        {previewUrl ? (
+          <audio controls src={previewUrl} className="w-full" />
+        ) : (
+          <div className="h-10 flex items-center justify-center text-[10px] text-gray-500">
+            Generated track
+          </div>
+        )}
+      </div>
+      <Handle type="target" position={Position.Left} id="video" />
+      <Handle type="target" position={Position.Left} id="prompt" style={{ top: '70%' }} />
+      <Handle type="source" position={Position.Right} id="audio" />
+    </div>
+  );
+};
+
 const LlmNode: React.FC<NodeProps<NodeData>> = ({ data }) => {
   const params = data.params || {};
   const updateParam = (key: string, value: string) => {
@@ -933,6 +983,7 @@ const nodeTypes = {
   faceRestore: FaceRestoreNode,
   bgRemove: BackgroundRemoveNode,
   rife: RifeNode,
+  music: MusicNode,
   llm: LlmNode,
 };
 
@@ -1039,6 +1090,14 @@ const paletteItems: PaletteItem[] = [
     description: 'Prompt or image-to-video generation with aspect control.',
     portLabel: 'prompt/media -> video',
     tone: 'from-rose-500/24 to-rose-500/5 border-rose-400/35',
+  },
+  {
+    type: 'music',
+    label: 'Music Model',
+    group: 'generation',
+    description: 'Original track generated from a rendered video (Sonilo).',
+    portLabel: 'video -> audio',
+    tone: 'from-pink-500/24 to-pink-500/5 border-pink-400/35',
   },
   {
     type: 'upscale',
@@ -1182,6 +1241,13 @@ const quickTemplateOptions: QuickTemplateOption[] = [
     backend: 'Cloud',
     nodeCount: 3,
   },
+  {
+    id: 'video-soundtrack',
+    label: 'Video Soundtrack',
+    description: 'Rendered cut into a Sonilo-generated original track.',
+    backend: 'Cloud',
+    nodeCount: 2,
+  },
 ];
 
 const IMAGE_MODEL_SET = new Set<string>([
@@ -1223,6 +1289,10 @@ const VIDEO_MODEL_SET = new Set<string>([
   'Wan I2V',
 ]);
 
+const MUSIC_MODEL_SET = new Set<string>([
+  'Sonilo Video-to-Music',
+]);
+
 const UPSCALE_IMAGE_SET = new Set<string>([
   'Crystal Upscaler',
   'Clarity Upscaler',
@@ -1249,17 +1319,17 @@ const IMAGE_OUTPUT_TYPES = new Set<NodeKind>([
 
 type PipelineTarget = {
   nodeId: string;
-  kind: 'image' | 'video' | 'text';
+  kind: 'image' | 'video' | 'audio' | 'text';
   prompt: string;
   model: string;
   imageInput?: string | null;
   secondaryInput?: string | null;
   params?: Record<string, any>;
-  task?: 'generate' | 'upscale' | 'filter' | 'chroma' | 'blend' | 'sketch' | 'openpose' | 'llm' | 'depth' | 'faceRestore' | 'bgRemove' | 'rife';
+  task?: 'generate' | 'upscale' | 'filter' | 'chroma' | 'blend' | 'sketch' | 'openpose' | 'llm' | 'depth' | 'faceRestore' | 'bgRemove' | 'rife' | 'music';
 };
 
 type EvaluatedOutput = {
-  kind: 'image' | 'video' | 'text';
+  kind: 'image' | 'video' | 'audio' | 'text';
   item?: MediaItem;
   text?: string;
   sourceType?: NodeKind;
@@ -1339,6 +1409,9 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
         break;
       case 'video':
         defaults = { label: 'Video', selected: 'Veo 3.1 Fast', params: { aspectRatio: '16:9', aspectRatioMode: 'preset', customAspectRatio: '' } };
+        break;
+      case 'music':
+        defaults = { label: 'Music', selected: 'Sonilo Video-to-Music', value: '' };
         break;
       case 'upscale':
         defaults = { label: 'Upscale', selected: 'Crystal Upscaler', params: { scale: 4, resolution: '' } };
@@ -1838,6 +1911,12 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
       link(interpolate, 'video', upscale, 'image');
     }
 
+    if (templateId === 'video-soundtrack') {
+      const video = add('imageInput', 0, 0, { label: 'Rendered Cut' });
+      const music = add('music', 360, 0, { label: 'Music' });
+      link(video, 'image', music, 'video');
+    }
+
     if (created.length === 0) return;
     const withHandlers = attachNodeHandlers(created);
     setNodes((prev) => prev.concat(withHandlers));
@@ -1936,6 +2015,7 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
       || node.type === 'faceRestore'
       || node.type === 'bgRemove'
       || node.type === 'rife'
+      || node.type === 'music'
       || node.type === 'llm'
     );
     if (outputNodes.length === 0) {
@@ -2205,6 +2285,31 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
             prompt: '',
             model: 'RIFE',
             task: 'rife',
+          });
+        }
+      }
+
+      if (node.type === 'music') {
+        const videoSource = findHandleSource(node.id, 'video');
+        const videoValue = videoSource?.data.value?.trim() || '';
+        const modelLabel = node.data.selected?.trim() || '';
+        if (!modelLabel) {
+          addError(`Music ${node.id} needs a model selection.`);
+        } else if (!MUSIC_MODEL_SET.has(modelLabel)) {
+          addError(`Music ${node.id} uses an unsupported model (${modelLabel}).`);
+        }
+        if (!videoSource) {
+          addError(`Music ${node.id} needs a video input.`);
+        } else if (videoSource?.type === 'imageInput' && videoValue && !isVideoAsset(videoValue)) {
+          addError(`Music ${node.id} requires a video URL.`);
+        }
+        if (isSink) {
+          pipelines.push({
+            nodeId: node.id,
+            kind: 'audio',
+            prompt: '',
+            model: modelLabel || 'Music',
+            task: 'music',
           });
         }
       }
@@ -2852,6 +2957,18 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
     return interpolateVideoWithRife(payload);
   }, [resolveAssetPayload]);
 
+  const runMusicPipeline = useCallback(async (inputUrl: string, promptText: string, sourceName?: string) => {
+    if (!hasSoniloApiKey()) {
+      throw new Error('Sonilo API key is missing. Add it in Settings.');
+    }
+    return generateMusicFromVideoWithSonilo({
+      videoUrl: inputUrl,
+      videoName: sourceName,
+      prompt: promptText || undefined,
+      onStatus: (message) => setRunStatus(message),
+    });
+  }, []);
+
   const runLlmPipeline = useCallback(async (promptText: string, params?: Record<string, any>) => {
     const model = params?.model || 'gemini-3-pro-replicate';
     const options = {
@@ -3093,6 +3210,18 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
         setNodePreview(node.id, itemWithMeta);
         return store({ kind: 'video', item: itemWithMeta, sourceType: node.type });
       }
+      case 'music': {
+        const input = await resolveMediaFromHandle(node.id, 'video', ['video']);
+        if (!input) {
+          throw new Error(`Music ${node.id} needs a video input.`);
+        }
+        const promptText = (await resolvePromptText(node.id)) || node.data.value?.trim() || '';
+        const modelLabel = node.data.selected?.trim() || 'Sonilo Video-to-Music';
+        const item = await runMusicPipeline(input.item.url, promptText, input.item.name);
+        const itemWithMeta = { ...item, generatedBy: modelLabel };
+        setNodePreview(node.id, itemWithMeta);
+        return store({ kind: 'audio', item: itemWithMeta, sourceType: node.type });
+      }
       case 'blend': {
         const base = await resolveMediaFromHandle(node.id, 'base', ['image']);
         const overlay = await resolveMediaFromHandle(node.id, 'overlay', ['image']);
@@ -3136,6 +3265,7 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
     runBackgroundRemovePipeline,
     runImagePipeline,
     runLlmPipeline,
+    runMusicPipeline,
     runOpenPosePipeline,
     runRifePipeline,
     runSketchPipeline,
@@ -3844,6 +3974,10 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
                           <div className="aspect-video overflow-hidden rounded bg-black/50">
                             {item.type === 'video' ? (
                               <video src={item.url} className="h-full w-full object-cover" />
+                            ) : item.type === 'audio' ? (
+                              <div className="flex h-full items-center justify-center px-2">
+                                <audio controls src={item.url} className="w-full" />
+                              </div>
                             ) : isLikelyImageUrl(item.url) ? (
                               <img src={item.url} alt={item.name} className="h-full w-full object-cover" />
                             ) : (

--- a/src/workspaces/NodeWorkspace.tsx
+++ b/src/workspaces/NodeWorkspace.tsx
@@ -71,7 +71,7 @@ import {
   upscaleVideoWithTopaz,
 } from '../services/replicateService';
 import { generateImageWithFalGrokImagine, generateImageWithFalQwenImageMax } from '../services/falAiService';
-import { generateMusicFromVideoWithSonilo, hasSoniloApiKey } from '../services/soniloService';
+import { generateMusicFromVideoWithSonilo, generateSfxFromVideoWithSonilo, hasSoniloApiKey } from '../services/soniloService';
 import { getBase64FromUrl } from '../utils/helpers';
 import { FILM_LUTS, buildFilterString, getBloomStrength, getGrainStrength, getHalationStrength, getVignetteStrength, normalizeFilters } from '../utils/colorGrading';
 import { applyCubeLutToImageData, parseCubeLut } from '../utils/lut';
@@ -95,7 +95,8 @@ type NodeKind =
   | 'faceRestore'
   | 'bgRemove'
   | 'rife'
-  | 'music';
+  | 'music'
+  | 'sfx';
 
 type NodeData = {
   label: string;
@@ -931,6 +932,54 @@ const MusicNode: React.FC<NodeProps<NodeData>> = ({ data }) => {
   );
 };
 
+const SfxNode: React.FC<NodeProps<NodeData>> = ({ data }) => {
+  const previewUrl = data.params?.previewUrl as string | undefined;
+  const keyReady = hasSoniloApiKey();
+  return (
+    <div className="bg-gray-900 border border-teal-500/40 rounded-lg p-3 min-w-[220px] text-gray-200">
+      <div className="text-xs uppercase tracking-[0.2em] text-teal-300">SFX</div>
+      <select
+        value={data.selected || ''}
+        onChange={(event) => data.onChange?.({ selected: event.target.value })}
+        className="mt-2 w-full bg-gray-800 text-white text-xs p-2 rounded border border-gray-700 focus:border-teal-500"
+      >
+        {(data.options || ['Sonilo Video-to-SFX']).map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+      <textarea
+        value={data.value || ''}
+        placeholder="Describe the sound effects (optional)..."
+        className="mt-2 w-full bg-gray-800 text-white text-xs p-2 rounded border border-gray-700 focus:border-teal-500"
+        rows={2}
+        onChange={(event) => data.onChange?.({ value: event.target.value })}
+      />
+      <div className="mt-2 text-[10px] text-gray-500">
+        Sound effects generated from the input video, timed to the picture (max 3 min).
+      </div>
+      {!keyReady && (
+        <div className="mt-2 text-[10px] text-amber-300">
+          Add a Sonilo API key in Settings to run this node.
+        </div>
+      )}
+      <div className="mt-2 rounded border border-dashed border-gray-700 p-2">
+        {previewUrl ? (
+          <audio controls src={previewUrl} className="w-full" />
+        ) : (
+          <div className="h-10 flex items-center justify-center text-[10px] text-gray-500">
+            Generated sound effects
+          </div>
+        )}
+      </div>
+      <Handle type="target" position={Position.Left} id="video" />
+      <Handle type="target" position={Position.Left} id="prompt" style={{ top: '70%' }} />
+      <Handle type="source" position={Position.Right} id="audio" />
+    </div>
+  );
+};
+
 const LlmNode: React.FC<NodeProps<NodeData>> = ({ data }) => {
   const params = data.params || {};
   const updateParam = (key: string, value: string) => {
@@ -984,6 +1033,7 @@ const nodeTypes = {
   bgRemove: BackgroundRemoveNode,
   rife: RifeNode,
   music: MusicNode,
+  sfx: SfxNode,
   llm: LlmNode,
 };
 
@@ -1098,6 +1148,14 @@ const paletteItems: PaletteItem[] = [
     description: 'Original track generated from a rendered video (Sonilo).',
     portLabel: 'video -> audio',
     tone: 'from-pink-500/24 to-pink-500/5 border-pink-400/35',
+  },
+  {
+    type: 'sfx',
+    label: 'SFX Model',
+    group: 'generation',
+    description: 'Royalty-free sound effects generated from a rendered video (Sonilo).',
+    portLabel: 'video -> audio',
+    tone: 'from-teal-500/24 to-teal-500/5 border-teal-400/35',
   },
   {
     type: 'upscale',
@@ -1248,6 +1306,13 @@ const quickTemplateOptions: QuickTemplateOption[] = [
     backend: 'Cloud',
     nodeCount: 2,
   },
+  {
+    id: 'video-sfx',
+    label: 'Video SFX',
+    description: 'Rendered cut into Sonilo-generated sound effects.',
+    backend: 'Cloud',
+    nodeCount: 2,
+  },
 ];
 
 const IMAGE_MODEL_SET = new Set<string>([
@@ -1293,6 +1358,10 @@ const MUSIC_MODEL_SET = new Set<string>([
   'Sonilo Video-to-Music',
 ]);
 
+const SFX_MODEL_SET = new Set<string>([
+  'Sonilo Video-to-SFX',
+]);
+
 const UPSCALE_IMAGE_SET = new Set<string>([
   'Crystal Upscaler',
   'Clarity Upscaler',
@@ -1325,7 +1394,7 @@ type PipelineTarget = {
   imageInput?: string | null;
   secondaryInput?: string | null;
   params?: Record<string, any>;
-  task?: 'generate' | 'upscale' | 'filter' | 'chroma' | 'blend' | 'sketch' | 'openpose' | 'llm' | 'depth' | 'faceRestore' | 'bgRemove' | 'rife' | 'music';
+  task?: 'generate' | 'upscale' | 'filter' | 'chroma' | 'blend' | 'sketch' | 'openpose' | 'llm' | 'depth' | 'faceRestore' | 'bgRemove' | 'rife' | 'music' | 'sfx';
 };
 
 type EvaluatedOutput = {
@@ -1412,6 +1481,9 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
         break;
       case 'music':
         defaults = { label: 'Music', selected: 'Sonilo Video-to-Music', value: '' };
+        break;
+      case 'sfx':
+        defaults = { label: 'SFX', selected: 'Sonilo Video-to-SFX', value: '' };
         break;
       case 'upscale':
         defaults = { label: 'Upscale', selected: 'Crystal Upscaler', params: { scale: 4, resolution: '' } };
@@ -1917,6 +1989,12 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
       link(video, 'image', music, 'video');
     }
 
+    if (templateId === 'video-sfx') {
+      const video = add('imageInput', 0, 0, { label: 'Rendered Cut' });
+      const sfx = add('sfx', 360, 0, { label: 'SFX' });
+      link(video, 'image', sfx, 'video');
+    }
+
     if (created.length === 0) return;
     const withHandlers = attachNodeHandlers(created);
     setNodes((prev) => prev.concat(withHandlers));
@@ -2016,6 +2094,7 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
       || node.type === 'bgRemove'
       || node.type === 'rife'
       || node.type === 'music'
+      || node.type === 'sfx'
       || node.type === 'llm'
     );
     if (outputNodes.length === 0) {
@@ -2310,6 +2389,31 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
             prompt: '',
             model: modelLabel || 'Music',
             task: 'music',
+          });
+        }
+      }
+
+      if (node.type === 'sfx') {
+        const videoSource = findHandleSource(node.id, 'video');
+        const videoValue = videoSource?.data.value?.trim() || '';
+        const modelLabel = node.data.selected?.trim() || '';
+        if (!modelLabel) {
+          addError(`SFX ${node.id} needs a model selection.`);
+        } else if (!SFX_MODEL_SET.has(modelLabel)) {
+          addError(`SFX ${node.id} uses an unsupported model (${modelLabel}).`);
+        }
+        if (!videoSource) {
+          addError(`SFX ${node.id} needs a video input.`);
+        } else if (videoSource?.type === 'imageInput' && videoValue && !isVideoAsset(videoValue)) {
+          addError(`SFX ${node.id} requires a video URL.`);
+        }
+        if (isSink) {
+          pipelines.push({
+            nodeId: node.id,
+            kind: 'audio',
+            prompt: '',
+            model: modelLabel || 'SFX',
+            task: 'sfx',
           });
         }
       }
@@ -2969,6 +3073,18 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
     });
   }, []);
 
+  const runSfxPipeline = useCallback(async (inputUrl: string, promptText: string, sourceName?: string) => {
+    if (!hasSoniloApiKey()) {
+      throw new Error('Sonilo API key is missing. Add it in Settings.');
+    }
+    return generateSfxFromVideoWithSonilo({
+      videoUrl: inputUrl,
+      videoName: sourceName,
+      prompt: promptText || undefined,
+      onStatus: (message) => setRunStatus(message),
+    });
+  }, []);
+
   const runLlmPipeline = useCallback(async (promptText: string, params?: Record<string, any>) => {
     const model = params?.model || 'gemini-3-pro-replicate';
     const options = {
@@ -3222,6 +3338,18 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
         setNodePreview(node.id, itemWithMeta);
         return store({ kind: 'audio', item: itemWithMeta, sourceType: node.type });
       }
+      case 'sfx': {
+        const input = await resolveMediaFromHandle(node.id, 'video', ['video']);
+        if (!input) {
+          throw new Error(`SFX ${node.id} needs a video input.`);
+        }
+        const promptText = (await resolvePromptText(node.id)) || node.data.value?.trim() || '';
+        const modelLabel = node.data.selected?.trim() || 'Sonilo Video-to-SFX';
+        const item = await runSfxPipeline(input.item.url, promptText, input.item.name);
+        const itemWithMeta = { ...item, generatedBy: modelLabel };
+        setNodePreview(node.id, itemWithMeta);
+        return store({ kind: 'audio', item: itemWithMeta, sourceType: node.type });
+      }
       case 'blend': {
         const base = await resolveMediaFromHandle(node.id, 'base', ['image']);
         const overlay = await resolveMediaFromHandle(node.id, 'overlay', ['image']);
@@ -3268,6 +3396,7 @@ const NodeWorkspaceContent: React.FC<NodeWorkspaceProps> = ({
     runMusicPipeline,
     runOpenPosePipeline,
     runRifePipeline,
+    runSfxPipeline,
     runSketchPipeline,
     runUpscalePipeline,
     runVideoPipeline,


### PR DESCRIPTION
## Summary

This PR now adds two Node Space nodes that run on one Sonilo API key: the music node proposed in #6, and an optional SFX node added since the PR was opened. It is bundled here rather than opened as a second PR so it stays a single review; the SFX addition is one separable commit (edff75b) on top of the music commit (8a096c3) if you would rather take them apart.

- **Music node:** takes the rendered cut from the graph and returns an original music track generated from that video, using the Sonilo video-to-music API. Output tracks are licensed, safe for commercial use (terms apply).
- **SFX node:** same input shape; returns royalty-free sound effects generated from the video and timed to the picture, using the Sonilo video-to-SFX API. Input cap is 3 minutes (music allows 6).

Per the condition in the issue discussion, the provider only runs with a user-supplied Sonilo API key: the key is entered in Settings and stored in localStorage exactly like the other provider keys (`sonilo_api_key`, same card pattern as Sonauto/LTX in `ApiKeyModal`), and the one key covers both nodes. Without a key, each node shows "Add a Sonilo API key in Settings to run this node" and execution fails fast with the same message style the other adapters use. No key ships with the app and nothing is proxied.

### What was touched: music node (8a096c3)

- **Workflow:** Node Space (`src/workspaces/NodeWorkspace.tsx`). New `music` node kind following the existing node conventions: palette entry (generation group, `video -> audio`), validation block modeled on the RIFE video-input checks, execution case in `resolveNodeOutput`, preview on the node (audio player), output added to project media like other generated assets, and a small "Video Soundtrack" quick template (Media In -> Music).
- **Provider adapter:** `src/services/soniloService.ts`, kept narrow per CONTRIBUTING. Request/response mapping is explicit: `POST https://api.sonilo.com/v1/video-to-music` with Bearer auth and multipart form (`video` file upload for local blob/data sources, `video_url` for remote HTTPS sources, optional `prompt` style hint). The response is an NDJSON event stream (`audio_chunk` base64 events, `title`, `complete`, `error`); the adapter accumulates the audio bytes and produces an `.m4a` (AAC-in-MP4) audio `MediaItem`. Follows the injectable-deps client pattern from `ltxService.ts` and the key-handling/usage-tracking conventions from `sonautoService.ts`.
- **Settings/status:** Sonilo card in `ApiKeyModal`, provider link + setup-status entries in `App.tsx`, `sonilo` added to `UsageProvider`.
- **Docs:** provider mentions in `README.md` and `docs/CAPABILITY_MAP.md` (provider-level, so they cover both nodes).

### What was touched: SFX node (edff75b)

- **Workflow:** Node Space again. New `sfx` node kind following the same conventions as the music node: palette entry (generation group, `video -> audio`), validation, execution case in `resolveNodeOutput`, audio preview on the node, output added to project media, and a "Video SFX" quick template (Media In -> SFX).
- **Provider adapter:** the SFX client in `src/services/soniloService.ts` uses a different transport than the music client because the endpoint is task-based rather than streaming: `POST https://api.sonilo.com/v1/video-to-sfx` returns a `task_id`, the client polls `/v1/tasks/{task_id}` until the task is terminal, then downloads the audio from a presigned result URL. The API key is only sent to the Sonilo API host, never to the storage domain (presigned URLs carry their own auth). A best-effort client-side pre-check rejects videos over the 3-minute SFX cap before upload; when the duration probe cannot read the file, the request goes through and the backend decides. The multipart video form builder is now shared between the two clients, and usage is recorded like the music node (`provider: 'sonilo'`, unit `clip`).
- **Settings:** the Sonilo card copy in `ApiKeyModal` now covers both nodes. Nothing else changed; the key storage and status entries from the music commit are reused as-is.

Provider API reference: both clients were implemented against the Sonilo MCP server source (https://github.com/sonilo-ai/sonilo-mcp, `src/sonilo_mcp/api.py`), which wraps the same REST endpoints. That source defines the music endpoint, auth header, form fields, NDJSON event types, error-body shape (`detail`), and limits, and as of v0.2.1 it also defines the SFX surface: the `/v1/video-to-sfx` submit endpoint, the `/v1/tasks/{task_id}` polling shape, artifact download, and the 3-minute SFX video cap (music stays at 6 minutes; ~300 MB upload cap for both). Sonilo does not appear to publish separate REST docs I could link, so the request/response mapping mirrors that source exactly; if the backend surface differs anywhere, the adapters are small and obvious to fix.

Disclosure, as in the issue: I work on Sonilo.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Model/provider adapter
- [ ] UI/UX
- [ ] Docs
- [ ] Refactor

## Checks

- [x] `npm run build:web`
- [x] `npm test`
- [x] `npm run check:icons`
- [x] `npm run check:public-release`
- [ ] Electron-specific checks, if applicable (no Electron runtime code changed)

I re-ran all four on the combined branch after the SFX commit.

## How this was tested

- `npm test`: 122 pass (109 pre-existing + 13 in `src/services/soniloService.test.ts`: 5 music, 8 SFX). The SFX tests exercise the task pipeline against a mocked `fetch`: happy path from a video URL and from a local file upload, missing-key fail-fast (no request made), the 3-minute pre-check plus the probe-failure fallback, submit-error and missing-task-id mapping, poll outcome mapping (failed, cancelled, unknown task id, unexpected status), and a polling timeout that keeps the task id in the message so the result stays recoverable.
- `npm run build:web`, `npm run check:icons`, `npm run check:public-release` all pass.
- **No live API call was made** for either node — same situation as before: I did not have a Sonilo key available in this environment, so both clients are verified against mocks that mirror the MCP server source. Happy to record a short clip of both nodes running end-to-end if useful before merge.

## Notes for reviewers

- Pricing metadata (CONTRIBUTING step 2) is not added because I don't have confirmed per-clip pricing to hard-code; both adapters record a usage entry (`provider: 'sonilo'`, unit `clip`) so a cost rate can be attached later like the Sonauto entries in `App.tsx`.
- The adapters call the API directly from the renderer, same as `sonautoService`/`ltxService`. If browser-mode CORS ever becomes an issue for the upload path, the desktop app is unaffected and the clients' `fetchImpl` injection point makes a proxy trivial to add.
- Neither node gates on the general `apiKeyReady` flag — they depend only on the Sonilo key, matching how the Sonauto path in `SoundWorkspace` bypasses the Replicate/Gemini readiness check.
